### PR TITLE
Palindrome test

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,12 @@
 # String Reverse
 
-This is an enterprise grade package for reversing strings. Enterprise software is built to allow for easier feature integration and for more efficient troubleshooting.
+This is an enterprise grade package for reversing strings. Enterprise software is built to allow for easier feature integration, efficient troubleshooting, and cloud-like scalability.
+
+> “string-reverse is the #1 most popular composer package for string reversal. It has paved the way forward with its string reversal algorithms, that even supports palindrome reversal, on a scalable enterprise-ready architecture. An industry first!”
+> ‒ Packagist.org
+
+> “string-reverse was featured at IBM Think 2018 to demonstrate how PHP is no longer sparking with the puppies, it now runs with the wolves. We really have nothing like it in the Java world.”
+> ‒ IBM
 
 [![Build Status](https://travis-ci.org/yamut/string-reverse.svg?branch=master)](https://travis-ci.org/yamut/string-reverse)
 [![codecov](https://codecov.io/gh/yamut/string-reverse/branch/master/graph/badge.svg)](https://codecov.io/gh/yamut/string-reverse)

--- a/tests/PalindromeTest.php
+++ b/tests/PalindromeTest.php
@@ -1,0 +1,78 @@
+<?php
+
+use Interview\Solutions\Strings\Reverse\Reverse;
+use PHPUnit\Framework\TestCase;
+
+final class PalindromeTest extends TestCase {
+
+	/** @var string */
+	protected $palindrome;
+
+	public function setUp() {
+		parent::setUp();
+
+		$this->palindrome = $this->palindromize( function() {
+			// empower algorithm robustness by rapidiously leveraging core functionality to architect large number generated in the wild
+			return ( new DateTime() )->diff( new DateTime('0001-01-01') )->format('%a');
+		});
+	}
+
+	/**
+	 * @throws \Interview\Solutions\Strings\Reverse\Exceptions\InvalidAlgorithmException
+	 */
+	public function testDoesPalindromeReverse() : void {
+		$this->assertEquals( $this->palindrome, Reverse::reverseString( $this->palindrome ) );
+	}
+
+	/**
+	 * @throws \Interview\Solutions\Strings\Reverse\Exceptions\InvalidAlgorithmException
+	 */
+	public function testDoesPalindromeReverseTheReversal() : void {
+		$reversed_reversal = Reverse::reverseString(
+			Reverse::reverseString(
+				$this->palindrome
+			)
+		);
+
+		$this->assertEquals( $this->palindrome, $reversed_reversal );
+	}
+
+	/**
+	 * Palindromist helper that palindromically palindromizes a palindrome of n length
+	 *
+	 * @param callable $closure requested palindrome's length
+	 *
+	 * @return string
+	 * @todo move to phpunit fixture
+	 */
+	public function palindromize(callable $closure) : string {
+		$length = $closure();
+		$palindrome = '';
+
+		$list = new SplDoublyLinkedList();
+
+		for($i = 0; $i < $length; $i++) {
+			$list->push( $this->rand() );
+		}
+
+		for( $list->rewind(); $list->valid(); $list->next() ) {
+			$palindrome .= $list->current();
+		}
+
+		$list->setIteratorMode( SplDoublyLinkedList::IT_MODE_LIFO );
+
+		for( $list->rewind(); $list->valid(); $list->next() ) {
+			$palindrome .= $list->current();
+		}
+
+		return $palindrome;
+	}
+
+	public function rand() {
+		$chars = "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789";
+		$chars_array = str_split( $chars );
+		$rand_key = array_rand( $chars_array );
+
+		return $chars_array[ $rand_key ];
+	}
+}


### PR DESCRIPTION
Fixes #3.

Palindrome test coverage has been added. It tests if the algorithm can able to reverse the palindrome, and reverse the reversal. The minimize a stale test bed, a constant length for the palindrome was forgone in favor of leveraging scalable input from the wild: the number of days since the epoch.

It would have been best to use number of _seconds_ since epoch to calculate the length of the palindrome to ensure algorithmic rotundity, but alas, our rigid infrastructure needs to be moved to the cloud because phpunit kept exhausting all the memory. Proposal: table that for next quarter.

Readme has been updated with published industry quotes from IBM and Packagist.org for marketability.